### PR TITLE
Bug/post nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
     <!-- Fixed navbar -->
     <nav id="mainNav" class="navbar navbar-light navbar-expand-lg bg-white fixed-top">
         <div class="container-lg">
-            <a class="navbar-brand" href="./">
+            <a class="navbar-brand" href="/">
                 <img src="/assets/img/como-logo.png" alt="COMo logo" width="190">
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarOffcanvasLg"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,9 +66,9 @@
 
     {% include footer.html %}
 
-    <script src="./assets/js/bootstrap.bundle.min.js"></script>
-    <script src="./assets/js/como.js"></script>
-    <script src="./assets/js/widget.js"></script>
+    <script src="/assets/js/bootstrap.bundle.min.js"></script>
+    <script src="/assets/js/como.js"></script>
+    <script src="/assets/js/widget.js"></script>
 
   </body>
 


### PR DESCRIPTION
There are two bugs concerning the navigation on the plog-post pages.

1. The js files have relative paths and aren't loaded in mobile view. That means the burger menu does not open.
2. The home button also has a relative href attribute and doesn't lead to the home screen.

That means when you are on a blogpost there is no way of navigating back on your phone.

![Screenshot 2022-05-30 at 09 01 24](https://user-images.githubusercontent.com/50147356/170936917-b6f2b4a3-9661-4120-84b5-857df45fc298.png)
![Screenshot 2022-05-30 at 09 01 13](https://user-images.githubusercontent.com/50147356/170936928-d06e9850-f38d-4583-852e-96d0cf61c7c5.png)

This should fix it. Any concerns about this?
